### PR TITLE
typo was back

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -50,7 +50,7 @@ install.packages('devtools')
 
 Quickpsy can be installed from CRAN
 ```R
-install.packages('quickspy')
+install.packages('quickpsy')
 ```
 
 To install the latest developed version, you can install quickpsy from github


### PR DESCRIPTION
I see now you generate the README.md file from here, which recreated the typo